### PR TITLE
make the client compatible with ES7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tmp
 _site
 .sass-cache
 file::memory:?cache=shared
+.idea

--- a/chewy.gemspec
+++ b/chewy.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec| # rubocop:disable BlockLength
   spec.add_development_dependency 'unparser'
 
   spec.add_dependency 'activesupport', '>= 4.0'
-  spec.add_dependency 'elasticsearch', '>= 2.0.0'
+  spec.add_dependency 'elasticsearch', '>= 7.0.0'
   spec.add_dependency 'elasticsearch-dsl'
 end

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -59,7 +59,7 @@ module Chewy
 
           body = specification_hash
           body[:aliases] = {general_name => {}} if options[:alias] && suffixed_name != general_name
-          result = client.indices.create(index: suffixed_name, body: body)
+          result = client.indices.create(index: suffixed_name, body: body, include_type_name: true)
 
           Chewy.wait_for_status if result
           result

--- a/lib/chewy/query.rb
+++ b/lib/chewy/query.rb
@@ -1101,7 +1101,8 @@ module Chewy
         index: _indexes.one? ? _indexes.first : _indexes,
         type: _types.one? ? _types.first : _types do
         begin
-          Chewy.client.search(_request)
+          request = _request.merge(rest_total_hits_as_int: true)
+          Chewy.client.search(request)
         rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
           raise e if e.message !~ /IndexMissingException/ && e.message !~ /index_not_found_exception/
           {}

--- a/lib/chewy/search.rb
+++ b/lib/chewy/search.rb
@@ -58,7 +58,7 @@ module Chewy
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-uri-request.html
       # @return [Hash] the request result
       def search_string(query, options = {})
-        options = options.merge(all.render.slice(:index, :type).merge(q: query))
+        options = options.merge(all.render.slice(:index, :type).merge(q: query)).merge(rest_total_hits_as_int: true)
         Chewy.client.search(options)
       end
 

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -978,6 +978,7 @@ module Chewy
         ActiveSupport::Notifications.instrument 'search_query.chewy',
           notification_payload(request: request_body) do
             begin
+              request_body = request_body.merge(rest_total_hits_as_int: true)
               Chewy.client.search(request_body)
             rescue Elasticsearch::Transport::Transport::Errors::NotFound
               {}

--- a/lib/chewy/type/syncer.rb
+++ b/lib/chewy/type/syncer.rb
@@ -207,7 +207,8 @@ module Chewy
 
         mappings = @type.client.indices.get_mapping(
           index: @type.index_name,
-          type: @type.type_name
+          type: @type.type_name,
+          include_type_name: true
         ).values.first.fetch('mappings', {})
 
         @outdated_sync_field_type = mappings


### PR DESCRIPTION
Chewy gem [hasn't been updated](https://github.com/toptal/chewy/issues/673#issuecomment-539442011) to adapt the changes in the new Elasticsearch versions (starting from v6), including
* The [removal support for mapping type](https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html)
*  **hits.total** is returned [as an object](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#hits-total-now-object-search-response)

This PR simply passed some string request parameters as supported by ES 7 as backward compatibility to make Chewy gem functions 

Pls note that this is simply a replicate of the changes [made by another guy](https://github.com/noellabo/chewy/commit/94e8a6cfc540e06c051d1217e13dda0d73442e8b) 
We don't use his repo directly because it is a few commits behind the main repo.
